### PR TITLE
feat: add multi-config merged coverage and file-specific filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,45 @@ make lcov-report
 # or
 make gcovr-report
 ```
+
+## Advanced: Merging coverage from multiple build configurations
+
+Real-world projects often compile the same source with different macros (feature flags, platform switches, etc.). You can combine the coverage from multiple configurations into a single report.
+
+`trigger.c` demonstrates this with `#ifdef TRIGGER_ON` / `#ifdef TRIGGER_OFF` conditional branches:
+
+```bash
+# Build and run both configurations, then merge into one report
+make coverage-merged
+# => merged-report/index.html
+```
+
+Under the hood, this uses `lcov --add-tracefile` to merge two separate `.info` files:
+
+```bash
+lcov -a config1.info -a config2.info -o merged.info
+genhtml merged.info --output-directory merged-report
+```
+
+## Advanced: File-specific coverage filtering
+
+To see coverage for a single file (e.g. `trigger.c`) rather than the whole project:
+
+```bash
+# First generate the full lcov report, then filter to trigger.c only
+make coverage-filter
+# => trigger-report/index.html
+```
+
+Using `lcov --extract` directly:
+
+```bash
+lcov --extract lcov-report/coverage.info "$(pwd)/trigger.c" -o trigger_only.info
+genhtml trigger_only.info --output-directory trigger-report
+```
+
+With gcovr, use `--filter`:
+
+```bash
+gcovr --filter trigger.c --html --html-details -o trigger-report/coverage.html
+```

--- a/makefile
+++ b/makefile
@@ -2,7 +2,8 @@ CC     = gcc
 CFLAGS = -fPIC -fprofile-arcs -ftest-coverage
 RM     = rm -rf
 
-.PHONY: help build coverage lcov-report gcovr-report deps clean lint
+.PHONY: help build coverage lcov-report gcovr-report deps clean lint \
+        build-config1 build-config2 coverage-merged coverage-filter
 
 help: ## Makefile help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -35,8 +36,37 @@ deps: ## Install dependencies (requires Debian/Ubuntu for apt-get)
 	sudo apt-get install lcov clang-format
 	pip install gcovr
 
+build-config1: ## Build with TRIGGER_ON macro (for multi-config coverage demo)
+	$(CC) $(CFLAGS) -DTRIGGER_ON -c -Wall -Werror trigger.c -o trigger_on.o
+	$(CC) $(CFLAGS) -c -Wall -Werror main.c foo.c test.c
+	$(CC) $(CFLAGS) -o main_config1 main.o foo.o test.o trigger_on.o
+
+build-config2: ## Build with TRIGGER_OFF macro (for multi-config coverage demo)
+	$(CC) $(CFLAGS) -c -Wall -Werror trigger.c -o trigger_off.o
+	$(CC) $(CFLAGS) -c -Wall -Werror main.c foo.c test.c
+	$(CC) $(CFLAGS) -o main_config2 main.o foo.o test.o trigger_off.o
+
+coverage-merged: build-config1 build-config2 ## Merge coverage from TRIGGER_ON and TRIGGER_OFF configurations
+	./main_config1
+	lcov --capture --directory . --output-file config1.info
+	$(RM) *.gcda
+	./main_config2
+	lcov --capture --directory . --output-file config2.info
+	lcov -a config1.info -a config2.info -o merged.info
+	mkdir -p merged-report
+	genhtml merged.info --output-directory merged-report
+	@echo "Merged coverage report: merged-report/index.html"
+
+coverage-filter: lcov-report ## Show coverage for trigger.c only (file-specific filtering)
+	lcov --extract lcov-report/coverage.info "$(CURDIR)/trigger.c" -o trigger_only.info
+	mkdir -p trigger-report
+	genhtml trigger_only.info --output-directory trigger-report
+	@echo "Filtered coverage report: trigger-report/index.html"
+
 clean: ## Clean all generate files
-	$(RM) main *.out *.o *.so *.gcno *.gcda *.gcov lcov-report gcovr-report
+	$(RM) main main_config1 main_config2 *.out *.o *.so *.gcno *.gcda *.gcov \
+	      lcov-report gcovr-report merged-report trigger-report \
+	      config1.info config2.info merged.info trigger_only.info
 
 lint: ## Lint code with clang-format
 	clang-format -i --style=LLVM *.c *.h

--- a/trigger.c
+++ b/trigger.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+#include "trigger.h"
+
+void trigger_action(void) {
+#ifdef TRIGGER_ON
+  printf("TRIGGER is ON: running extra logic...\n");
+#else
+  printf("TRIGGER is OFF: running default logic...\n");
+#endif
+}

--- a/trigger.h
+++ b/trigger.h
@@ -1,0 +1,6 @@
+#ifndef TRIGGER_H
+#define TRIGGER_H
+
+void trigger_action(void);
+
+#endif /* TRIGGER_H */


### PR DESCRIPTION
- Add trigger.c/trigger.h with #ifdef TRIGGER_ON/#ifdef TRIGGER_OFF branches to demonstrate coverage under different macro configurations
- Add Makefile targets:
  - build-config1 / build-config2: compile with TRIGGER_ON / TRIGGER_OFF
  - coverage-merged: run both configs and merge with lcov --add-tracefile
  - coverage-filter: extract single-file coverage with lcov --extract
- Update clean target to remove new artifacts
- Update README with Advanced sections documenting both workflows

Resolves: https://github.com/shenxianpeng/gcov-example/issues/1

## Description

<!-- Provide a concise summary of the changes and the motivation behind them. -->

## Type of Change

<!-- Check all that apply. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 👻 Maintenance / chore

## Related Issues

Closes #1

## Checklist

- [x] My changes follow the project's coding style
- [x] I have performed a self-review of my own changes
- [ ] I have added or updated tests where applicable
- [x] I have updated documentation where applicable
